### PR TITLE
fix : ignore du package lock en prévision du prochain commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,4 @@ expo-env.d.ts
 # @end expo-cli
 
 bun.lockb
+package-lock.json

--- a/app/src/components/FriendRequestItem.tsx
+++ b/app/src/components/FriendRequestItem.tsx
@@ -18,10 +18,10 @@ const FriendRequestItem: React.FC<FriendRequestItemProps> = ({
   return (
     <View style={styles.itemContainer}>
       <View style={styles.avatarContainer}>
-        <Text style={styles.avatarText}>{emoji}</Text>
+        <Text style={styles.avatarText}>{emoji || "👤"}</Text>
       </View>
       <View style={styles.nameContainer}>
-        <Text style={styles.name}>{name}</Text>
+        <Text style={styles.name}>{name || "Unknown"}</Text>
       </View>
       <TouchableOpacity style={styles.actionButton} onPress={onAction}>
         <Text style={styles.actionButtonText}>

--- a/app/src/screens/FriendRequestScreen.tsx
+++ b/app/src/screens/FriendRequestScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, TouchableOpacity, ScrollView } from "react-native";
+import { View, Text, TouchableOpacity, ScrollView, SafeAreaView } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import FontAwesome from "react-native-vector-icons/FontAwesome";
 import FriendRequestItem from "../components/FriendRequestItem";
@@ -21,14 +21,14 @@ const FriendRequestScreen: React.FC = () => {
   };
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <View style={styles.topBar}>
         <View style={styles.topBarContent}>
           <TouchableOpacity onPress={() => navigation.goBack()}>
             <FontAwesome name="arrow-left" size={24} color="#1E232C" />
           </TouchableOpacity>
           <Text style={styles.title}>Friend Requests</Text>
-          <View style={{ width: 24 }} /> {/* Spacer for alignment */}
+          <View style={{ width: 24 }} />
         </View>
       </View>
 
@@ -81,7 +81,7 @@ const FriendRequestScreen: React.FC = () => {
           <Text style={styles.addNewButtonText}>Add New Friend</Text>
         </TouchableOpacity>
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -46,7 +46,7 @@ const HomeScreen: React.FC = () => {
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={() => navigation.navigate("Profile")}>
+        <TouchableOpacity onPress={() => navigation.navigate('Profile' as never)}>
           <Image
             source={{
               uri: "https://cdn.builder.io/api/v1/image/assets/TEMP/f3d67917c6442fafa158ab0bdb706f7194e5a329b13b72692715ec90abbf8ce7?placeholderIfAbsent=true&width=100 100w, https://cdn.builder.io/api/v1/image/assets/TEMP/f3d67917c6442fafa158ab0bdb706f7194e5a329b13b72692715ec90abbf8ce7?placeholderIfAbsent=true&width=200 200w, https://cdn.builder.io/api/v1/image/assets/TEMP/f3d67917c6442fafa158ab0bdb706f7194e5a329b13b72692715ec90abbf8ce7?placeholderIfAbsent=true&width=400 400w, https://cdn.builder.io/api/v1/image/assets/TEMP/f3d67917c6442fafa158ab0bdb706f7194e5a329b13b72692715ec90abbf8ce7?placeholderIfAbsent=true&width=800 800w, https://cdn.builder.io/api/v1/image/assets/TEMP/f3d67917c6442fafa158ab0bdb706f7194e5a329b13b72692715ec90abbf8ce7?placeholderIfAbsent=true&width=1200 1200w, https://cdn.builder.io/api/v1/image/assets/TEMP/f3d67917c6442fafa158ab0bdb706f7194e5a329b13b72692715ec90abbf8ce7?placeholderIfAbsent=true&width=1600 1600w, https://cdn.builder.io/api/v1/image/assets/TEMP/f3d67917c6442fafa158ab0bdb706f7194e5a329b13b72692715ec90abbf8ce7?placeholderIfAbsent=true&width=2000 2000w, https://cdn.builder.io/api/v1/image/assets/TEMP/f3d67917c6442fafa158ab0bdb706f7194e5a329b13b72692715ec90abbf8ce7?placeholderIfAbsent=true",

--- a/app/src/screens/JobsScreen.tsx
+++ b/app/src/screens/JobsScreen.tsx
@@ -146,7 +146,7 @@ const JobsScreen: React.FC = () => {
         {/* Create Job Button */}
         <TouchableOpacity
           style={styles.createButton}
-          onPress={() => navigation.navigate("CreateJobOffer")}
+          onPress={() => navigation.navigate("CreateJobOffer" as never)}
         >
           <Text style={styles.createButtonText}>Create a job offer</Text>
         </TouchableOpacity>


### PR DESCRIPTION
This pull request includes several changes to improve the robustness and compatibility of the React Native components in the app. The most important changes include adding default values for missing props in the `FriendRequestItem` component, using `SafeAreaView` in the `FriendRequestScreen`, and updating navigation type assertions in the `HomeScreen` and `JobsScreen`.

Improvements to component robustness:

* [`app/src/components/FriendRequestItem.tsx`](diffhunk://#diff-17b40b2225c75da20eabb9522e250fc14f9de44aa1cb82370874733545afcf5aL21-R24): Added default values for `emoji` and `name` props to ensure the component displays fallback values if these props are missing.

Enhancements to screen components:

* [`app/src/screens/FriendRequestScreen.tsx`](diffhunk://#diff-a41b654b4ed739a5ad87ce51fbc1b4f87358bdf2199267a35a9bf557165822d0L2-R2): Replaced `View` with `SafeAreaView` to ensure the content is displayed within the safe area boundaries on iOS devices. [[1]](diffhunk://#diff-a41b654b4ed739a5ad87ce51fbc1b4f87358bdf2199267a35a9bf557165822d0L2-R2) [[2]](diffhunk://#diff-a41b654b4ed739a5ad87ce51fbc1b4f87358bdf2199267a35a9bf557165822d0L24-R31) [[3]](diffhunk://#diff-a41b654b4ed739a5ad87ce51fbc1b4f87358bdf2199267a35a9bf557165822d0L84-R84)

Type assertion updates for navigation:

* [`app/src/screens/HomeScreen.tsx`](diffhunk://#diff-ba4c337b708e3a0c25b0c312babb2712d7cb9282d36226de94b8e53fd1d63799L49-R49): Updated the navigation method to include type assertions, ensuring type safety when navigating to the "Profile" screen.
* [`app/src/screens/JobsScreen.tsx`](diffhunk://#diff-7daaed82657bf8a83dea9e21dbb853c0719580319b1edcb08a54791c15cac725L149-R149): Updated the navigation method to include type assertions, ensuring type safety when navigating to the "CreateJobOffer" screen.